### PR TITLE
Non override method binded from derived type fix.

### DIFF
--- a/Tests/CPythonClassTestModule.cpp
+++ b/Tests/CPythonClassTestModule.cpp
@@ -22,6 +22,8 @@ namespace sweetPyTest {
         subject.AddMethod("GetBByNoCopyConstructible", "Return a rvalue instance of non copy constructable type", &TestSubjectA::GetBNonCopyConstructable);
         subject.AddMethod("IncBByRef", "Will increase b internal ref count", &TestSubjectA::IncBByRef);
         subject.AddMethod("IncB", "Will increase b internal ref count", &TestSubjectA::IncB);
+        subject.AddMethod("IncBaseValue", "Will increase base class member value", &TestSubjectA::IncBaseValue);
+        subject.AddMethod("GetBaseValue", "Will get base class member value", &TestSubjectA::GetBaseValue);
         subject.AddStaticMethod("GetUniqueMe", "GetUniqueMe - Return an rvalue reference of non supported type", &TestSubjectA::GetUniqueMe);
         subject.AddStaticMethod("Setter", "Setter - will change the value of m_valid into true", &TestSubjectA::Setter);
         subject.AddStaticMethod("Getter", "Getter - will retrieve m_valid", &TestSubjectA::Getter);

--- a/Tests/CPythonClassTestModule.h
+++ b/Tests/CPythonClassTestModule.h
@@ -44,7 +44,18 @@ namespace sweetPyTest {
         std::string m_str;
     };
 
-    class TestSubjectA {
+    class TestSubjectAAbastract
+    {
+    public:
+        TestSubjectAAbastract():m_value{}{}
+        virtual void IncBaseValue(){m_value++;}
+        virtual int GetBaseValue(){return m_value;}
+
+    private:
+        int m_value;
+    };
+
+    class TestSubjectA : public TestSubjectAAbastract{
     public:
         TestSubjectA(int &valueInt) : m_byValueInt(valueInt), m_enumValue(Python::Good) {}
         ~TestSubjectA(){ m_instanceDestroyed = true; }

--- a/Tests/Tests.cpp
+++ b/Tests/Tests.cpp
@@ -77,6 +77,15 @@ namespace sweetPyTest {
         ASSERT_EQ(PythonEmbedder::GetAttribute<int>("a.byValueInt"), PythonEmbedder::GetAttribute<int>("b"));
     }
 
+    TEST(CPythonClassTest, NonOveridedVirtualFunctionCall) {
+        const char *testingScript = "a = TestClass(7)\n"
+                                    "a.IncBaseValue()\n"
+                                    "result = a.GetBaseValue()";
+
+        PyRun_SimpleString(testingScript);
+        ASSERT_EQ(PythonEmbedder::GetAttribute<int>("result"), 1);
+    }
+
     TEST(CPythonClassTest, HandleArgumentConversionofNonPythonType) {
         const char *testingScript = "a = TestClass(7)\n"
                                     "s = 'Hello World'\n"

--- a/src/CPythonFunction.h
+++ b/src/CPythonFunction.h
@@ -18,11 +18,12 @@ namespace sweetPy {
         virtual ~CPythonFunction(){}
     };
 
-    template<typename ClassType, typename Return, typename... Args>
-    class CPythonFunction<ClassType, Return(ClassType::*)(Args...)> : public ICPythonFunction{
+    template<typename ClassType, typename MemberFunctionType, typename Return, typename... Args>
+    class CPythonFunction<ClassType, Return(MemberFunctionType::*)(Args...)> : public ICPythonFunction{
     public:
-        typedef Return(ClassType::*MemberFunction)(Args...);
-        typedef CPythonFunction<ClassType, Return(ClassType::*)(Args...)> Self;
+        typedef Return(MemberFunctionType::*MemberFunction)(Args...);
+        typedef CPythonFunction<ClassType, Return(MemberFunctionType::*)(Args...)> Self;
+        typedef typename std::enable_if<std::is_base_of<MemberFunctionType, ClassType>::value>::type VirtualSupport;
 
         CPythonFunction(const std::string& name, const std::string doc, const MemberFunction &memberMethod)
                 : m_name(name), m_doc(doc), m_memberMethod(memberMethod) {
@@ -142,11 +143,11 @@ namespace sweetPy {
         std::string m_doc;
     };
 
-    template<typename ClassType, typename Return, typename... Args>
-    class CPythonFunction<ClassType, Return(ClassType::*)(Args...) const> : public ICPythonFunction{
+    template<typename ClassType, typename MemberFunctionType, typename Return, typename... Args>
+    class CPythonFunction<ClassType, Return(MemberFunctionType::*)(Args...) const> : public ICPythonFunction{
     public:
-        typedef Return(ClassType::*MemberFunction)(Args...) const;
-        typedef CPythonFunction<ClassType, Return(ClassType::*)(Args...) const> Self;
+        typedef Return(MemberFunctionType::*MemberFunction)(Args...) const;
+        typedef CPythonFunction<ClassType, Return(MemberFunctionType::*)(Args...) const> Self;
 
         CPythonFunction(const std::string& name, const std::string doc, const MemberFunction &memberMethod)
                 : m_name(name), m_doc(doc), m_memberMethod(memberMethod) {


### PR DESCRIPTION
A fix to CPythonFunction being unable to handle non overrided method being binded from the derived type.