### PR TITLE
A more refiend ObjectOffset.

### DIFF
--- a/src/CPythonConstructor.h
+++ b/src/CPythonConstructor.h
@@ -28,15 +28,15 @@ namespace sweetPy {
             char pythonArgsBuffer[ObjectsPackSize<typename Object<typename base<Args>::Type>::FromPythonType...>::value];
             char nativeArgsBuffer[ObjectsPackSize<typename Object<typename base<Args>::Type>::Type...>::value];
             {
-                CPYTHON_VERIFY(PyArg_ParseTuple(args, format.c_str(), (pythonArgsBuffer + ObjectOffset<ObjectWrapper<typename base<Args>::Type, I>,
+                CPYTHON_VERIFY(PyArg_ParseTuple(args, format.c_str(), (pythonArgsBuffer + ObjectOffset<ToNative, ObjectWrapper<typename base<Args>::Type, I>,
                         ObjectWrapper<typename base<Args>::Type, I>...>::value)...), "Invalid argument was provided");
             }
             new((char*)self + sizeof(PyObject))ClassType(std::forward<Args>(Object<typename base<Args>::Type>::GetTyped(
-                    pythonArgsBuffer + FromPythonObjectOffset<ObjectWrapper<typename base<Args>::Type, I>,ObjectWrapper<typename base<Args>::Type, I>...>::value,
-                    nativeArgsBuffer + ObjectOffset<ObjectWrapper<typename base<Args>::Type, I>,ObjectWrapper<typename base<Args>::Type, I>...>::value))...);
+                    pythonArgsBuffer + ObjectOffset<FromPython, ObjectWrapper<typename base<Args>::Type, I>,ObjectWrapper<typename base<Args>::Type, I>...>::value,
+                    nativeArgsBuffer + ObjectOffset<ToNative, ObjectWrapper<typename base<Args>::Type, I>,ObjectWrapper<typename base<Args>::Type, I>...>::value))...);
 
             ObjectWrapper<int, 0>::MultiInvoker(ObjectWrapper<typename base<Args>::Type, I>::Destructor(nativeArgsBuffer +
-                                                                                                            ObjectOffset<ObjectWrapper<typename base<Args>::Type, I>,
+                                                                                                            ObjectOffset<ToNative, ObjectWrapper<typename base<Args>::Type, I>,
                                                                                                                     ObjectWrapper<typename base<Args>::Type, I>...>::value)...);
             return 0;
         }

--- a/src/CPythonFunction.h
+++ b/src/CPythonFunction.h
@@ -57,7 +57,7 @@ namespace sweetPy {
             char pythonArgsBuffer[ObjectsPackSize<typename Object<typename base<Args>::Type>::FromPythonType...>::value];
             char nativeArgsBuffer[ObjectsPackSize<typename Object<typename base<Args>::Type>::Type...>::value];
             {
-                CPYTHON_VERIFY(PyArg_ParseTuple(args, format.c_str(), (pythonArgsBuffer + FromPythonObjectOffset<ObjectWrapper<typename base<Args>::Type, I>,
+                CPYTHON_VERIFY(PyArg_ParseTuple(args, format.c_str(), (pythonArgsBuffer + ObjectOffset<FromPython, ObjectWrapper<typename base<Args>::Type, I>,
                         ObjectWrapper<typename base<Args>::Type, I>...>::value)...), "Invalid argument was provided");
             }
 
@@ -69,11 +69,11 @@ namespace sweetPy {
 
             Self& m_pyFunc = static_cast<Self&>(CPyModuleContainer::Instance().GetMethod(typeid(Self).hash_code()));
             Return returnValue = (_this->*m_pyFunc.m_memberMethod)(std::forward<Args>(Object<typename base<Args>::Type>::GetTyped(
-                    pythonArgsBuffer + FromPythonObjectOffset<ObjectWrapper<typename base<Args>::Type, I>,ObjectWrapper<typename base<Args>::Type, I>...>::value,
-                    nativeArgsBuffer + ObjectOffset<ObjectWrapper<typename base<Args>::Type, I>,ObjectWrapper<typename base<Args>::Type, I>...>::value))...);
+                    pythonArgsBuffer + ObjectOffset<FromPython, ObjectWrapper<typename base<Args>::Type, I>,ObjectWrapper<typename base<Args>::Type, I>...>::value,
+                    nativeArgsBuffer + ObjectOffset<ToNative, ObjectWrapper<typename base<Args>::Type, I>,ObjectWrapper<typename base<Args>::Type, I>...>::value))...);
 
             ObjectWrapper<int, 0>::MultiInvoker(ObjectWrapper<typename base<Args>::Type, I>::Destructor(nativeArgsBuffer +
-                    ObjectOffset<ObjectWrapper<typename base<Args>::Type, I>,
+                    ObjectOffset<ToNative, ObjectWrapper<typename base<Args>::Type, I>,
                             ObjectWrapper<typename base<Args>::Type, I>...>::value)...);
 
             return Object<Return>::ToPython(returnValue);
@@ -89,7 +89,7 @@ namespace sweetPy {
             char pythonArgsBuffer[ObjectsPackSize<typename Object<typename base<Args>::Type>::FromPythonType...>::value];
             char nativeArgsBuffer[ObjectsPackSize<typename Object<typename base<Args>::Type>::Type...>::value];
             {
-                CPYTHON_VERIFY(PyArg_ParseTuple(args, format.c_str(), (pythonArgsBuffer + FromPythonObjectOffset<ObjectWrapper<typename base<Args>::Type, I>,
+                CPYTHON_VERIFY(PyArg_ParseTuple(args, format.c_str(), (pythonArgsBuffer + ObjectOffset<FromPython, ObjectWrapper<typename base<Args>::Type, I>,
                         ObjectWrapper<typename base<Args>::Type, I>...>::value)...), "Invalid argument was provided");
             }
 
@@ -101,11 +101,11 @@ namespace sweetPy {
 
             Self& m_pyFunc = static_cast<Self&>(CPyModuleContainer::Instance().GetMethod(typeid(Self).hash_code()));
             (_this->*m_pyFunc.m_memberMethod)(std::forward<Args>(Object<typename base<Args>::Type>::GetTyped(
-                    pythonArgsBuffer + FromPythonObjectOffset<ObjectWrapper<typename base<Args>::Type, I>,ObjectWrapper<typename base<Args>::Type, I>...>::value,
-                    nativeArgsBuffer + ObjectOffset<ObjectWrapper<typename base<Args>::Type, I>,ObjectWrapper<typename base<Args>::Type, I>...>::value))...);
+                    pythonArgsBuffer + ObjectOffset<FromPython, ObjectWrapper<typename base<Args>::Type, I>,ObjectWrapper<typename base<Args>::Type, I>...>::value,
+                    nativeArgsBuffer + ObjectOffset<ToNative, ObjectWrapper<typename base<Args>::Type, I>,ObjectWrapper<typename base<Args>::Type, I>...>::value))...);
 
             ObjectWrapper<int, 0>::MultiInvoker(ObjectWrapper<typename base<Args>::Type, I>::Destructor(nativeArgsBuffer +
-                                                                                                            ObjectOffset<ObjectWrapper<typename base<Args>::Type, I>,
+                                                                                                            ObjectOffset<ToNative, ObjectWrapper<typename base<Args>::Type, I>,
                                                                                                                     ObjectWrapper<typename base<Args>::Type, I>...>::value)...);
             return Py_None;
         }
@@ -181,7 +181,7 @@ namespace sweetPy {
             char pythonArgsBuffer[ObjectsPackSize<typename Object<typename base<Args>::Type>::FromPythonType...>::value];
             char nativeArgsBuffer[ObjectsPackSize<typename Object<typename base<Args>::Type>::Type...>::value];
             {
-                CPYTHON_VERIFY(PyArg_ParseTuple(args, format.c_str(), (pythonArgsBuffer + FromPythonObjectOffset<ObjectWrapper<typename base<Args>::Type, I>,
+                CPYTHON_VERIFY(PyArg_ParseTuple(args, format.c_str(), (pythonArgsBuffer + ObjectOffset<FromPython, ObjectWrapper<typename base<Args>::Type, I>,
                         ObjectWrapper<typename base<Args>::Type, I>...>::value)...), "Invalid argument was provided");
             }
 
@@ -193,11 +193,11 @@ namespace sweetPy {
 
             Self& m_pyFunc = static_cast<Self&>(CPyModuleContainer::Instance().GetMethod(typeid(Self).hash_code()));
             Return returnValue = (_this->*m_pyFunc.m_memberMethod)(std::forward<Args>(Object<typename base<Args>::Type>::GetTyped(
-                    pythonArgsBuffer + FromPythonObjectOffset<ObjectWrapper<typename base<Args>::Type, I>,ObjectWrapper<typename base<Args>::Type, I>...>::value,
-                    nativeArgsBuffer + ObjectOffset<ObjectWrapper<typename base<Args>::Type, I>,ObjectWrapper<typename base<Args>::Type, I>...>::value))...);
+                    pythonArgsBuffer + ObjectOffset<FromPython, ObjectWrapper<typename base<Args>::Type, I>,ObjectWrapper<typename base<Args>::Type, I>...>::value,
+                    nativeArgsBuffer + ObjectOffset<ToNative, ObjectWrapper<typename base<Args>::Type, I>,ObjectWrapper<typename base<Args>::Type, I>...>::value))...);
 
             ObjectWrapper<int, 0>::MultiInvoker(ObjectWrapper<typename base<Args>::Type, I>::Destructor(nativeArgsBuffer +
-                                                                                                            ObjectOffset<ObjectWrapper<typename base<Args>::Type, I>,
+                                                                                                            ObjectOffset<ToNative, ObjectWrapper<typename base<Args>::Type, I>,
                                                                                                                     ObjectWrapper<typename base<Args>::Type, I>...>::value)...);
             return Object<Return>::ToPython(returnValue);
         }
@@ -212,7 +212,7 @@ namespace sweetPy {
             char pythonArgsBuffer[ObjectsPackSize<typename Object<typename base<Args>::Type>::FromPythonType...>::value];
             char nativeArgsBuffer[ObjectsPackSize<typename Object<typename base<Args>::Type>::Type...>::value];
             {
-                CPYTHON_VERIFY(PyArg_ParseTuple(args, format.c_str(), (pythonArgsBuffer + FromPythonObjectOffset<ObjectWrapper<typename base<Args>::Type, I>,
+                CPYTHON_VERIFY(PyArg_ParseTuple(args, format.c_str(), (pythonArgsBuffer + ObjectOffset<FromPython, ObjectWrapper<typename base<Args>::Type, I>,
                         ObjectWrapper<typename base<Args>::Type, I>...>::value)...), "Invalid argument was provided");
             }
 
@@ -224,11 +224,11 @@ namespace sweetPy {
 
             Self& m_pyFunc = static_cast<Self&>(CPyModuleContainer::Instance().GetMethod(typeid(Self).hash_code()));
             (_this->*m_pyFunc.m_memberMethod)(std::forward<Args>(Object<typename base<Args>::Type>::GetTyped(
-                    pythonArgsBuffer + FromPythonObjectOffset<ObjectWrapper<typename base<Args>::Type, I>,ObjectWrapper<typename base<Args>::Type, I>...>::value,
-                    nativeArgsBuffer + ObjectOffset<ObjectWrapper<typename base<Args>::Type, I>,ObjectWrapper<typename base<Args>::Type, I>...>::value))...);
+                    pythonArgsBuffer + ObjectOffset<FromPython, ObjectWrapper<typename base<Args>::Type, I>,ObjectWrapper<typename base<Args>::Type, I>...>::value,
+                    nativeArgsBuffer + ObjectOffset<ToNative, ObjectWrapper<typename base<Args>::Type, I>,ObjectWrapper<typename base<Args>::Type, I>...>::value))...);
 
             ObjectWrapper<int, 0>::MultiInvoker(ObjectWrapper<typename base<Args>::Type, I>::Destructor(nativeArgsBuffer +
-                                                                                                            ObjectOffset<ObjectWrapper<typename base<Args>::Type, I>,
+                                                                                                            ObjectOffset<ToNative, ObjectWrapper<typename base<Args>::Type, I>,
                                                                                                                     ObjectWrapper<typename base<Args>::Type, I>...>::value)...);
             return Py_None;
         }
@@ -303,16 +303,16 @@ namespace sweetPy {
             char pythonArgsBuffer[ObjectsPackSize<typename Object<typename base<Args>::Type>::FromPythonType...>::value];
             char nativeArgsBuffer[ObjectsPackSize<typename Object<typename base<Args>::Type>::Type...>::value];
             {
-                CPYTHON_VERIFY(PyArg_ParseTuple(args, format.c_str(), (pythonArgsBuffer + FromPythonObjectOffset<ObjectWrapper<typename base<Args>::Type, I>,
+                CPYTHON_VERIFY(PyArg_ParseTuple(args, format.c_str(), (pythonArgsBuffer + ObjectOffset<FromPython, ObjectWrapper<typename base<Args>::Type, I>,
                         ObjectWrapper<typename base<Args>::Type, I>...>::value)...), "Invalid argument was provided");
             }
             Self& m_pyFunc = static_cast<Self&>(CPyModuleContainer::Instance().GetStaticMethod(typeid(Self).hash_code()));
             Return returnValue = (*m_pyFunc.m_staticMethod)(std::forward<Args>(Object<typename base<Args>::Type>::GetTyped(
-                    pythonArgsBuffer + FromPythonObjectOffset<ObjectWrapper<typename base<Args>::Type, I>,ObjectWrapper<typename base<Args>::Type, I>...>::value,
-                    nativeArgsBuffer + ObjectOffset<ObjectWrapper<typename base<Args>::Type, I>,ObjectWrapper<typename base<Args>::Type, I>...>::value))...);
+                    pythonArgsBuffer + ObjectOffset<FromPython, ObjectWrapper<typename base<Args>::Type, I>,ObjectWrapper<typename base<Args>::Type, I>...>::value,
+                    nativeArgsBuffer + ObjectOffset<ToNative, ObjectWrapper<typename base<Args>::Type, I>,ObjectWrapper<typename base<Args>::Type, I>...>::value))...);
 
             ObjectWrapper<int, 0>::MultiInvoker(ObjectWrapper<typename base<Args>::Type, I>::Destructor(nativeArgsBuffer +
-                                                                                                            ObjectOffset<ObjectWrapper<typename base<Args>::Type, I>,
+                                                                                                            ObjectOffset<ToNative, ObjectWrapper<typename base<Args>::Type, I>,
                                                                                                                     ObjectWrapper<typename base<Args>::Type, I>...>::value)...);
             return Object<Return>::ToPython(returnValue);
         }
@@ -327,16 +327,16 @@ namespace sweetPy {
             char pythonArgsBuffer[ObjectsPackSize<typename Object<typename base<Args>::Type>::FromPythonType...>::value];
             char nativeArgsBuffer[ObjectsPackSize<typename Object<typename base<Args>::Type>::Type...>::value];
             {
-                CPYTHON_VERIFY(PyArg_ParseTuple(args, format.c_str(), (pythonArgsBuffer + FromPythonObjectOffset<ObjectWrapper<typename base<Args>::Type, I>,
+                CPYTHON_VERIFY(PyArg_ParseTuple(args, format.c_str(), (pythonArgsBuffer + ObjectOffset<FromPython, ObjectWrapper<typename base<Args>::Type, I>,
                         ObjectWrapper<typename base<Args>::Type, I>...>::value)...), "Invalid argument was provided");
             }
             Self& m_pyFunc = static_cast<Self&>(CPyModuleContainer::Instance().GetStaticMethod(typeid(Self).hash_code()));
             (*m_pyFunc.m_staticMethod)(std::forward<Args>(Object<typename base<Args>::Type>::GetTyped(
-                    pythonArgsBuffer + FromPythonObjectOffset<ObjectWrapper<typename base<Args>::Type, I>,ObjectWrapper<typename base<Args>::Type, I>...>::value,
-                    nativeArgsBuffer + ObjectOffset<ObjectWrapper<typename base<Args>::Type, I>,ObjectWrapper<typename base<Args>::Type, I>...>::value))...);
+                    pythonArgsBuffer + ObjectOffset<FromPython, ObjectWrapper<typename base<Args>::Type, I>,ObjectWrapper<typename base<Args>::Type, I>...>::value,
+                    nativeArgsBuffer + ObjectOffset<ToNative, ObjectWrapper<typename base<Args>::Type, I>,ObjectWrapper<typename base<Args>::Type, I>...>::value))...);
 
             ObjectWrapper<int, 0>::MultiInvoker(ObjectWrapper<typename base<Args>::Type, I>::Destructor(nativeArgsBuffer +
-                                                                                                            ObjectOffset<ObjectWrapper<typename base<Args>::Type, I>,
+                                                                                                            ObjectOffset<ToNative, ObjectWrapper<typename base<Args>::Type, I>,
                                                                                                                     ObjectWrapper<typename base<Args>::Type, I>...>::value)...);
             return Py_None;
         }

--- a/src/CPythonObject.h
+++ b/src/CPythonObject.h
@@ -394,36 +394,38 @@ namespace sweetPy{
         static const int value = sizeof(Type) + ObjectsPackSize<Args...>::value;
     };
 
-    template<typename... Args>
-    struct FromPythonObjectOffset{};
-
-
-    template<typename T, typename... Args>
-    struct FromPythonObjectOffset<T, T, Args...>
+    enum OffsetType : short
     {
-        static const int value = 0;
+        FromPython,
+        ToNative
     };
 
-    template<typename T, typename X, typename... Args>
-    struct FromPythonObjectOffset<T, X, Args...>
-    {
-        static const int value = FromPythonObjectOffset<T, Args...>::value + sizeof(typename X::FromPythonType);
-    };
-
-    template<typename... Args>
+    template<OffsetType, typename... Args>
     struct ObjectOffset{};
 
 
     template<typename T, typename... Args>
-    struct ObjectOffset<T, T, Args...>
+    struct ObjectOffset<FromPython, T, T, Args...>
+    {
+        static const int value = 0;
+    };
+
+    template<typename T, typename... Args>
+    struct ObjectOffset<ToNative, T, T, Args...>
     {
         static const int value = 0;
     };
 
     template<typename T, typename X, typename... Args>
-    struct ObjectOffset<T, X, Args...>
+    struct ObjectOffset<FromPython, T, X, Args...>
     {
-        static const int value = ObjectOffset<T, Args...>::value + sizeof(typename X::Type);
+        static const int value = ObjectOffset<FromPython, T, Args...>::value + sizeof(typename X::FromPythonType);
+    };
+
+    template<typename T, typename X, typename... Args>
+    struct ObjectOffset<ToNative, T, X, Args...>
+    {
+        static const int value = ObjectOffset<ToNative, T, Args...>::value + sizeof(typename X::Type);
     };
 
     template<typename T, std::size_t I>


### PR DESCRIPTION
Both two use cases of ObjectOffset - FromPython and ToNative have been merged into a single struct with specific specialization for each use case.

Closes #9.