### PR TITLE
std::string&& type paramater type is now supported.

### DIFF
--- a/Tests/CPythonClassTestModule.cpp
+++ b/Tests/CPythonClassTestModule.cpp
@@ -32,6 +32,8 @@ namespace sweetPyTest {
         subject.AddMember("byValueInt", &TestSubjectA::m_byValueInt, "int by value member support");
         subject.AddMember("ctypeStr", &TestSubjectA::m_ctypeStr, "c-type string member support");
         subject.AddMethod("SetPython", "Will set the python enum value", &TestSubjectA::SetPython);
+        subject.AddMethod("GetStr", "Will return a reference to m_str", &TestSubjectA::GetStr);
+        subject.AddMethod("SetXpireValue", "Will set m_str from an xpire value", &TestSubjectA::SetXpireValue);
 
         CPythonClass<TestSubjectB> subjectB(module, "TestClassB", "TestClassB");
         subjectB.AddMethod("IncValue", "Will increase b internal ref count", &TestSubjectB::IncValue);

--- a/Tests/CPythonClassTestModule.h
+++ b/Tests/CPythonClassTestModule.h
@@ -62,6 +62,8 @@ namespace sweetPyTest {
         TestSubjectA(int &valueInt) : m_byValueInt(valueInt), m_enumValue(Python::Good) {}
         ~TestSubjectA(){ m_instanceDestroyed = true; }
         virtual int GetValue(){ return m_byValueInt;}
+        const std::string& GetStr() const{return m_str;}
+        void SetXpireValue(std::string&& str){m_str = str;}
         std::string SetString(const std::string& str){
             return m_str = str + " Temp";
         }

--- a/Tests/Tests.cpp
+++ b/Tests/Tests.cpp
@@ -189,6 +189,14 @@ namespace sweetPyTest {
         ASSERT_EQ(PythonEmbedder::GetAttribute<int>("result"), 5);
     }
 
+    TEST(CPythonClassTest, FromPythonStrToNativeXpireStrArgument) {
+        const char *testingScript = "a = TestClass(5)\n"
+                                    "a.SetXpireValue('Xpire Value')\n"
+                                    "strRef = a.GetStr()";
+        PyRun_SimpleString(testingScript);
+        ASSERT_EQ(PythonEmbedder::GetAttribute<std::string&>("strRef"), "Xpire Value");
+    }
+
 }
 
 int main(int argc, char **argv) {


### PR DESCRIPTION
1) It is now possible to convert received Python string into Rvalue std::string/Xpire Value global value std::string.