### PR TITLE
More fixes to how types are handled, tuple supports all types conversion

### DIFF
--- a/Tests/CPythonClassTestModule.cpp
+++ b/Tests/CPythonClassTestModule.cpp
@@ -105,6 +105,7 @@ namespace sweetPyTest {
         CPythonGlobalFunction(module, "check_const_ref_timedelta_conversion", "check const TimeDelta& type conversions", static_cast<const sweetPy::TimeDelta&(*)(const sweetPy::TimeDelta&)>(&CheckConstRefTimeDeltaType));
         CPythonGlobalFunction(module, "check_tuple_conversion", "check Tuple type conversions", static_cast<sweetPy::Tuple(*)(sweetPy::Tuple)>(&CheckTuleType));
         CPythonGlobalFunction(module, "check_const_ref_tuple_conversion", "check const Tuple& type conversions", static_cast<const sweetPy::Tuple&(*)(const sweetPy::Tuple&)>(&CheckConstRefTupleType));
+        CPythonGlobalFunction(module, "generate_native_element_tuple", "Will generate a native tuple which will hold non supported element type", static_cast<sweetPy::Tuple(*)()>(&GenerateNativeElementTuple));
 
         CPythonGlobalVariable(module, "globalVariableStr", "Hello World");
         CPythonGlobalVariable(module, "globalVariableInt", 5);

--- a/Tests/CPythonClassTestModule.h
+++ b/Tests/CPythonClassTestModule.h
@@ -8,8 +8,141 @@
 #include "Types/DateTime.h"
 #include "Types/TimeDelta.h"
 #include "Types/Tuple.h"
+#include "CPythonObject.h"
 
 namespace sweetPyTest {
+
+    enum Python
+    {
+        Good = 1,
+        Bad = 3
+    };
+
+    int globalFunction(int i){return i;}
+
+    class TestSubjectC{
+    public:
+        TestSubjectC(const TestSubjectC&) = delete;
+        TestSubjectC& operator=(const TestSubjectC&) = delete;
+        TestSubjectC(const TestSubjectC&&) = delete;
+        TestSubjectC& operator=(const TestSubjectC&&) = delete;
+        static TestSubjectC& Instance(){
+            static TestSubjectC c{};
+            return c;
+        }
+        void Inc(){i++;}
+
+    public:
+        int i;
+
+    private:
+        TestSubjectC(){}
+
+    };
+
+    class TestSubjectB{
+    public:
+        TestSubjectB():m_value(0), m_str("Hello World"){}
+        void IncValue(){m_value++;}
+        int GetValue() const { return m_value; }
+        const std::string& GetStr() const { return m_str; }
+        int Foo(int i){ return i; }
+        int Foo(int i, int y){return i+y;}
+
+    public:
+        int m_value;
+        std::string m_str;
+    };
+
+    class TestSubjectAAbastract
+    {
+    public:
+        TestSubjectAAbastract():m_value{}{}
+        virtual void IncBaseValue(){m_value++;}
+        virtual int GetBaseValue(){return m_value;}
+    private:
+        int m_value;
+    };
+
+    class TestSubjectA : public TestSubjectAAbastract{
+    public:
+        TestSubjectA(int valueInt) : m_byValueInt(valueInt), m_enumValue(Python::Good) {}
+        ~TestSubjectA(){ m_instanceDestroyed = true; }
+        virtual int GetValue(){ return m_byValueInt;}
+        const std::string& GetStr() const{return m_str;}
+        void SetXpireValue(std::string&& str){m_str = str;}
+        std::string SetString(const std::string& str){
+            return m_str = str + " Temp";
+        }
+
+        static std::unique_ptr<TestSubjectA> GetUniqueMe(){
+            static int i = 5;
+            return std::unique_ptr<TestSubjectA>(new TestSubjectA(i));
+        }
+
+        TestSubjectA& GetMe(){
+            return *this;
+        }
+
+        void SetPython(Python enumValue){
+            m_enumValue = enumValue;
+        }
+
+        const TestSubjectB& GetB() const{
+            return m_b;
+        }
+
+        TestSubjectB GetBByValue() const{
+            return m_b;
+        }
+
+        void IncBByRef(std::unique_ptr<TestSubjectB>& b) const
+        {
+            b->IncValue();
+        }
+
+        void IncB(std::unique_ptr<TestSubjectB> b) const
+        {
+            b->IncValue();
+        }
+
+        std::unique_ptr<TestSubjectB> GetBNonCopyConstructable() const{
+            return std::unique_ptr<TestSubjectB>(new TestSubjectB(m_b));
+        }
+
+        std::vector<int> FromStrVectorToIntVector(const std::vector<std::string>& strVector)
+        {
+            std::vector<int> intVector;
+            for(const std::string& str : strVector)
+                intVector.push_back(str.length());
+            return intVector;
+        }
+
+        static void BMutator(TestSubjectB& obj){
+            obj.IncValue();
+        }
+
+        static void Setter() {
+            m_valid = true;
+        }
+
+        static bool Getter() {
+            return m_valid;
+        }
+        static bool GetInstancDestroyed(){
+            return m_instanceDestroyed;
+        }
+
+    public:
+        static bool m_valid;
+        static bool m_instanceDestroyed;
+        int m_byValueInt;
+        TestSubjectB m_b;
+        std::string m_str;
+        Python m_enumValue;
+        const char* m_ctypeStr;
+    };
+
 
     template<typename T>
     class GenerateRefTypes
@@ -109,139 +242,17 @@ namespace sweetPyTest {
         return values.back();
     }
 
+    sweetPy::Tuple GenerateNativeElementTuple()
+    {
+        sweetPy::Tuple tuple;
+        static TestSubjectB testSubjectB;
+        tuple.AddElement(0, testSubjectB, [](void const * const ptr) -> PyObject*{
+            const TestSubjectB& value = *reinterpret_cast<const TestSubjectB*>(ptr);
+            return sweetPy::Object<TestSubjectB>::ToPython(value);
+        });
+        return tuple;
+    }
+
     PyObject* CheckIntegralPyObjectType(PyObject* value){ return value; }
-
-
-
-    enum Python
-    {
-        Good = 1,
-        Bad = 3
-    };
-
-    int globalFunction(int i){return i;}
-
-    class TestSubjectC{
-    public:
-        TestSubjectC(const TestSubjectC&) = delete;
-        TestSubjectC& operator=(const TestSubjectC&) = delete;
-        TestSubjectC(const TestSubjectC&&) = delete;
-        TestSubjectC& operator=(const TestSubjectC&&) = delete;
-        static TestSubjectC& Instance(){
-            static TestSubjectC c{};
-            return c;
-        }
-        void Inc(){i++;}
-
-    public:
-        int i;
-
-    private:
-        TestSubjectC(){}
-
-    };
-
-    class TestSubjectB{
-    public:
-        TestSubjectB():m_value(0), m_str("Hello World"){}
-        void IncValue(){m_value++;}
-        int GetValue() const { return m_value; }
-        int Foo(int i){ return i; }
-        int Foo(int i, int y){return i+y;}
-
-    public:
-        int m_value;
-        std::string m_str;
-    };
-
-    class TestSubjectAAbastract
-    {
-    public:
-        TestSubjectAAbastract():m_value{}{}
-        virtual void IncBaseValue(){m_value++;}
-        virtual int GetBaseValue(){return m_value;}
-    private:
-        int m_value;
-    };
-
-    class TestSubjectA : public TestSubjectAAbastract{
-    public:
-        TestSubjectA(int valueInt) : m_byValueInt(valueInt), m_enumValue(Python::Good) {}
-        ~TestSubjectA(){ m_instanceDestroyed = true; }
-        virtual int GetValue(){ return m_byValueInt;}
-        const std::string& GetStr() const{return m_str;}
-        void SetXpireValue(std::string&& str){m_str = str;}
-        std::string SetString(const std::string& str){
-            return m_str = str + " Temp";
-        }
-
-        static std::unique_ptr<TestSubjectA> GetUniqueMe(){
-            static int i = 5;
-            return std::unique_ptr<TestSubjectA>(new TestSubjectA(i));
-        }
-
-        TestSubjectA& GetMe(){
-            return *this;
-        }
-
-        void SetPython(Python enumValue){
-            m_enumValue = enumValue;
-        }
-
-        const TestSubjectB& GetB() const{
-            return m_b;
-        }
-
-        TestSubjectB GetBByValue() const{
-            return m_b;
-        }
-
-        void IncBByRef(std::unique_ptr<TestSubjectB>& b) const
-        {
-            b->IncValue();
-        }
-
-        void IncB(std::unique_ptr<TestSubjectB> b) const
-        {
-            b->IncValue();
-        }
-
-        std::unique_ptr<TestSubjectB> GetBNonCopyConstructable() const{
-            return std::unique_ptr<TestSubjectB>(new TestSubjectB(m_b));
-        }
-
-        std::vector<int> FromStrVectorToIntVector(const std::vector<std::string>& strVector)
-        {
-            std::vector<int> intVector;
-            for(const std::string& str : strVector)
-                intVector.push_back(str.length());
-            return intVector;
-        }
-
-        static void BMutator(TestSubjectB& obj){
-            obj.IncValue();
-        }
-
-        static void Setter() {
-            m_valid = true;
-        }
-
-        static bool Getter() {
-            return m_valid;
-        }
-        static bool GetInstancDestroyed(){
-            return m_instanceDestroyed;
-        }
-
-    public:
-        static bool m_valid;
-        static bool m_instanceDestroyed;
-        int m_byValueInt;
-        TestSubjectB m_b;
-        std::string m_str;
-        Python m_enumValue;
-        const char* m_ctypeStr;
-    };
-
 }
 

--- a/Tests/Tests.cpp
+++ b/Tests/Tests.cpp
@@ -283,7 +283,10 @@ namespace sweetPyTest {
                 "tupleReturn_3 = TestModule.check_const_ref_tuple_conversion(tupleArgument_3) #tuple -> const Tuple&\n"
                 "tupleArgument_4 = (None,)\n"
                 "tupleConstRefObject_2 = tupleConstRefGenerator.create(tupleArgument_4)\n"
-                "tupleReturn_4 = TestModule.check_const_ref_tuple_conversion(tupleConstRefObject_2) #const Tuple& -> const Tuple&";
+                "tupleReturn_4 = TestModule.check_const_ref_tuple_conversion(tupleConstRefObject_2) #const Tuple& -> const Tuple&\n"
+                //Transformation of non supported type element into python representation
+                "tupleReturn_5 = TestModule.generate_native_element_tuple()\n"
+                "value = tupleReturn_5[0]";
 
         PyRun_SimpleString(testingScript);
         //Tuple
@@ -304,7 +307,7 @@ namespace sweetPyTest {
         ASSERT_EQ(std::string("Goodbye"), tupleReturn_2.GetElement<std::string>(2));
         ASSERT_EQ(std::string("World"), tupleReturn_2.GetElement<std::string>(3));
         ASSERT_EQ(true, tupleReturn_2.GetElement<bool>(4));
-
+        //const Tuple&
         sweetPy::Tuple tupleArgument_3 = PythonEmbedder::GetAttribute<sweetPy::Tuple>("tupleArgument_3");
         ASSERT_EQ(0, tupleArgument_3.GetElement<bool>(0));
         ASSERT_EQ(std::string("to all"), tupleArgument_3.GetElement<std::string>(1));
@@ -321,6 +324,10 @@ namespace sweetPyTest {
 
         const sweetPy::Tuple& tupleReturn_4 = PythonEmbedder::GetAttribute<const sweetPy::Tuple&>("tupleReturn_4");
         ASSERT_EQ(nullptr, tupleReturn_4.GetElement<void*>(0));
+        //Transformation of non supported type element into python representation
+        TestSubjectB& value = PythonEmbedder::GetAttribute<TestSubjectB&>("value");
+        ASSERT_EQ(value.GetValue(), 0);
+        ASSERT_EQ(value.GetStr(), "Hello World");
 
         //Check native type
         sweetPy::Tuple tuple;

--- a/src/CPythonConcreteFunction.h
+++ b/src/CPythonConcreteFunction.h
@@ -16,6 +16,19 @@
 
 namespace sweetPy {
 
+    template<typename T, typename std::enable_if<std::is_copy_constructible<T>::value, bool>::type = true>
+    static PyObject* ConvertReturn(T& returnValue)
+    {
+        return Object<T>::ToPython(returnValue);
+    }
+
+    template<typename T, typename std::enable_if<!std::is_copy_constructible<T>::value &&
+                                                 std::is_move_constructible<T>::value, bool>::type = true>
+    static PyObject* ConvertReturn(T& returnValue)
+    {
+        return Object<T>::ToPython(std::move(returnValue));
+    }
+
     template<typename Return, typename... Args>
     class CPythonMemberFunction: public CPythonFunction {
         virtual ~CPythonMemberFunction(){}
@@ -80,7 +93,7 @@ namespace sweetPy {
                     ObjectOffset<ToNative, ObjectWrapper<typename base<Args>::Type, I>,
                             ObjectWrapper<typename base<Args>::Type, I>...>::value)...);
 
-            return Object<Return>::ToPython(returnValue);
+            return ConvertReturn<Return>(returnValue);
         }
 
         template<bool Enable = true, std::size_t... I>
@@ -207,7 +220,7 @@ namespace sweetPy {
             ObjectWrapper<int, 0>::MultiInvoker(ObjectWrapper<typename base<Args>::Type, I>::Destructor(nativeArgsBuffer +
                                                                                                             ObjectOffset<ToNative, ObjectWrapper<typename base<Args>::Type, I>,
                                                                                                                     ObjectWrapper<typename base<Args>::Type, I>...>::value)...);
-            return Object<Return>::ToPython(returnValue);
+            return ConvertReturn<Return>(returnValue);
         }
 
         template<bool Enable = true, std::size_t... I>
@@ -330,7 +343,7 @@ namespace sweetPy {
             ObjectWrapper<int, 0>::MultiInvoker(ObjectWrapper<typename base<Args>::Type, I>::Destructor(nativeArgsBuffer +
                                                                                                             ObjectOffset<ToNative, ObjectWrapper<typename base<Args>::Type, I>,
                                                                                                                     ObjectWrapper<typename base<Args>::Type, I>...>::value)...);
-            return Object<Return>::ToPython(returnValue);
+            return ConvertReturn<Return>(returnValue);
         }
 
         template<bool Enable = true, std::size_t... I>
@@ -446,7 +459,7 @@ namespace sweetPy {
             ObjectWrapper<int, 0>::MultiInvoker(ObjectWrapper<typename base<Args>::Type, I>::Destructor(nativeArgsBuffer +
                                                                                                         ObjectOffset<ToNative, ObjectWrapper<typename base<Args>::Type, I>,
                                                                                                                             ObjectWrapper<typename base<Args>::Type, I>...>::value)...);
-            return Object<Return>::ToPython(returnValue);
+            return ConvertReturn<Return>(returnValue);
         }
 
         template<bool Enable = true, std::size_t... I>

--- a/src/Types/Tuple.cpp
+++ b/src/Types/Tuple.cpp
@@ -3,6 +3,13 @@
 
 namespace sweetPy{
 
+    Tuple::Converter::Converter(void const * value, const ConveterFunc &converter): m_value(value), m_converter(converter) {}
+
+    Tuple::Converter::operator PyObject *() const
+    {
+       return m_converter(m_value);
+    }
+
     Tuple::Tuple() {}
 
     Tuple::Tuple(PyObject *tuple)
@@ -123,8 +130,16 @@ namespace sweetPy{
                 object = Object<bool>::ToPython(static_cast<core::TypedParam<bool>&>(*m_elements[idx]).Get<bool>());
             else
             {
-                Py_XINCREF(Py_None);
-                object = Py_None;
+                auto it = m_converters.find(idx);
+                if(it != m_converters.end())
+                {
+                    object = it->second;
+                }
+                else
+                {
+                    Py_XINCREF(Py_None);
+                    object = Py_None;
+                }
             }
             PyTuple_SetItem(tuple.get(), idx, object);
         }


### PR DESCRIPTION
Tuple:
1) Non integral or plain old data type may be added in Tuple native form, a special converter functor needs to be provided by the user in order to support - "Python conversion".
Type Conversion:
1) Non explicit supported types allocation is more refined to support all value category variations.
2) Few corrections - By value T can be constructed from a reference.
3) Few corrections - By value T which only supports move constructor will always use the move constructor.
Functions:
1) Return value will handle value category in a more correct manner.